### PR TITLE
feat(config): Configure app-config.yaml for Crossplane XRD auto-discovery

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -106,7 +106,48 @@ kubernetes:
     type: 'multiTenant'
   clusterLocatorMethods:
     - type: 'config'
-      clusters: []
+      clusters:
+        - name: digiorg-core-dev
+          url: ${KUBERNETES_API_URL}
+          authProvider: serviceAccount
+          serviceAccountToken: ${KUBERNETES_SERVICE_ACCOUNT_TOKEN}
+          skipTLSVerify: true
+
+kubernetesIngestor:
+  # Global settings
+  enabled: true
+  defaultOwner: platform-team
+  allowAllClusters: true
+
+  # Standard Kubernetes workload components
+  components:
+    enabled: true
+    disableDefaultWorkloadTypes: false
+
+  # Crossplane integration
+  crossplane:
+    enabled: true
+
+    # Ingest AppClaims as Backstage Component entities
+    claims:
+      ingestAllClaims: true
+      ingestAsResources: false
+
+    # Ingest AppClaim XRD as Backstage Template + API entity
+    xrds:
+      enabled: true
+      ingestAllXRDs: true
+      ingestOnlyAsAPI: false
+      convertDefaultValuesToPlaceholders: true
+
+      # Phase 1: catalog download (no git push required)
+      publishPhase:
+        target: catalog
+
+      # Refresh every 5 minutes
+      taskRunner:
+        frequency: 300
+        timeout: 300
 
 permission:
   enabled: true


### PR DESCRIPTION
## Summary
Configures `app-config.yaml` for the TeraSky `kubernetes-ingestor` plugin installed in P-1. The plugin now connects to the `digiorg-core-dev` cluster and automatically discovers the AppClaim XRD (`platform.digiorg.io/v1alpha1/Application`), generating a Backstage Scaffolder Template and API entity from it.

## Changes
- `app-config.yaml`: Updated `kubernetes.clusters` with `digiorg-core-dev` cluster entry (env-var references for URL + token)
- `app-config.yaml`: Added `kubernetesIngestor:` section with Crossplane XRD auto-discovery config

## Key configuration
- `kubernetesIngestor.crossplane.xrds.ingestAllXRDs: true` — discovers AppClaim XRD without requiring annotations
- `kubernetesIngestor.crossplane.claims.ingestAllClaims: true` — ingests existing AppClaims as Backstage Components
- `publishPhase.target: catalog` — Phase 1: YAML download (no git push required)
- Refresh: every 5 minutes

## Environment variables required (set in ArgoCD deployment)
- `KUBERNETES_API_URL` — Kubernetes API server URL
- `KUBERNETES_SERVICE_ACCOUNT_TOKEN` — ServiceAccount token with cluster read access

## Acceptance Criteria
- [x] kubernetes.clusters has digiorg-core-dev entry with env-var references
- [x] kubernetesIngestor section added with crossplane.enabled: true
- [x] crossplane.xrds.ingestAllXRDs: true
- [x] crossplane.claims.ingestAllClaims: true
- [x] publishPhase.target: catalog
- [x] All other config sections unchanged

Fixes digiorg/core-portal#7